### PR TITLE
test: Simplify the glob used to find tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,5 @@ can then open in a browser and print to PDF, for example.
 - [ ] Add some CLI logging and user-friendly exception catching
 - [ ] Add support for validating input data with JSON Schema (either built-in
 or user-provided)
+- [ ] Write the last tests
 - [ ] Maybe allow for automatically converting the output HTML file to PDF

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "microgen": "./bin/build.js"
   },
   "scripts": {
-    "test": "node --test --test-reporter=spec tests/**/*.test.js"
+    "test": "node --test --test-reporter=spec tests"
   },
   "dependencies": {
     "pug": "^3.0.2"


### PR DESCRIPTION
The fact that the basenames of the test files are suffixed with
`.test.js` is enough for Node to find them anyway.
